### PR TITLE
Port ASIO host to new stream-based API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hound = "3.4"
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "std", "synchapi", "winuser"] }
 asio-sys = { version = "0.1", path = "asio-sys", optional = true }
+parking_lot = "0.9"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 alsa-sys = { version = "0.1", path = "alsa-sys" }

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -1,4 +1,5 @@
 extern crate asio_sys as sys;
+extern crate parking_lot;
 
 use {
     BuildStreamError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ pub struct SupportedFormat {
 }
 
 /// Stream data passed to the `EventLoop::run` callback.
+#[derive(Debug)]
 pub enum StreamData<'a> {
     Input {
         buffer: UnknownTypeInputBuffer<'a>,
@@ -213,6 +214,7 @@ pub enum StreamData<'a> {
 /// same way as reading from a `Vec` or any other kind of Rust array.
 // TODO: explain audio stuff in general
 // TODO: remove the wrapper and just use slices in next major version
+#[derive(Debug)]
 pub struct InputBuffer<'a, T: 'a>
 where
     T: Sample,
@@ -228,6 +230,7 @@ where
 // TODO: explain audio stuff in general
 // TODO: remove the wrapper and just use slices
 #[must_use]
+#[derive(Debug)]
 pub struct OutputBuffer<'a, T: 'a>
 where
     T: Sample,
@@ -238,6 +241,7 @@ where
 /// This is the struct that is provided to you by cpal when you want to read samples from a buffer.
 ///
 /// Since the type of data is only known at runtime, you have to read the right buffer.
+#[derive(Debug)]
 pub enum UnknownTypeInputBuffer<'a> {
     /// Samples whose format is `u16`.
     U16(InputBuffer<'a, u16>),
@@ -250,6 +254,7 @@ pub enum UnknownTypeInputBuffer<'a> {
 /// This is the struct that is provided to you by cpal when you want to write samples to a buffer.
 ///
 /// Since the type of data is only known at runtime, you have to fill the right buffer.
+#[derive(Debug)]
 pub enum UnknownTypeOutputBuffer<'a> {
     /// Samples whose format is `u16`.
     U16(OutputBuffer<'a, u16>),

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -458,9 +458,8 @@ mod platform_impl {
     pub use crate::host::asio::{
         Device as AsioDevice,
         Devices as AsioDevices,
-        EventLoop as AsioEventLoop,
+        Stream as AsioStream,
         Host as AsioHost,
-        StreamId as AsioStreamId,
         SupportedInputFormats as AsioSupportedInputFormats,
         SupportedOutputFormats as AsioSupportedOutputFormats,
     };


### PR DESCRIPTION
An implementation for the ASIO host on top of the new stream-based API. Based on initial discussion on RustAudio discord.

Design choices:
- ASIO supports only a single input/output stream, which need to be created at the same time. This means for now that (due to lack of duplex stream api) there is no way to use input and output for an ASIO driver atm. The previous implementation solved this via access synchronization to rebuild the buffers on the fly -> API changes would be benficial
- As ASIO uses exclusive device sharing, there is no concurrent access emulation implemented in the host so far.
- Play/pause functionality is on device level in ASIO in contrast to the cpal API (on stream level). We currently just implement this software side via a bool. The native functions are not called, only on stream creation
- We currently use the `set_callback` API provided by the ASIO wrapper of cpal which internally realizes support for multiple callbacks -> current only source of locking inside the callback executing.

Missing pieces:
- [ ] Stream dropping needs to be implemented, also a bit unsure about the lifetime situation as a device or host might be dropped before a stream as far as I can see right now.